### PR TITLE
Add player autocomplete

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,5 @@
 # app.py
-from flask import Flask, render_template, request, redirect
+from flask import Flask, render_template, request, redirect, jsonify
 from tag_utils import process_clip_tags
 from pathlib import Path
 
@@ -7,6 +7,16 @@ app = Flask(__name__)
 
 # Store path separately so we can reuse it
 CLIP_STATE = {"filename": "", "path": ""}
+
+@app.route("/players")
+def players():
+    base = Path("/Volumes/Samsung PSSD T7/NBAFilm")
+    names = []
+    if base.exists():
+        for entry in base.iterdir():
+            if entry.is_dir() and not entry.name.startswith("_") and not entry.name.startswith("."):
+                names.append(entry.name)
+    return jsonify({"players": names})
 
 @app.route("/tag")
 def tag_form():

--- a/templates/tagger.html
+++ b/templates/tagger.html
@@ -19,6 +19,22 @@
         }, 100);
       }
 
+      async function loadPlayers() {
+        try {
+          const res = await fetch("/players");
+          if (!res.ok) return;
+          const data = await res.json();
+          const list = document.getElementById("player-list");
+          data.players.forEach((p) => {
+            const opt = document.createElement("option");
+            opt.value = p;
+            list.appendChild(opt);
+          });
+        } catch (e) {
+          console.error("Failed to load players", e);
+        }
+      }
+
       window.onload = function () {
         const lastPlayer = localStorage.getItem("lastPlayer");
         const lastSide = localStorage.getItem("lastSide");
@@ -31,6 +47,7 @@
           });
           document.querySelector('input[name="side"]').value = lastSide;
         }
+        loadPlayers();
       };
 
       function toggleSelectLabel(event) {
@@ -73,7 +90,8 @@
       <h1>Tag Clip: {{ clip.filename }}</h1>
       <form method="POST" action="/submit" onsubmit="closeAfterSubmit()">
         <div class="form-row">
-          <input name="player" placeholder="LeBron James" required />
+          <input name="player" placeholder="LeBron James" required list="player-list" />
+          <datalist id="player-list"></datalist>
           <div class="toggle-group">
             <div
               class="toggle-button selected"


### PR DESCRIPTION
## Summary
- add `/players` API to list previously tagged players
- populate player input `datalist` from `/players` for autocompletion

## Testing
- `python3 -m py_compile app.py tagger.py watcher.py tag_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_686a34de71b88326b1dc858bea4af87c