### PR TITLE
Improve player name suggestions

### DIFF
--- a/app.py
+++ b/app.py
@@ -36,6 +36,9 @@ def get_player_names():
         for entry in base.iterdir():
             if entry.is_dir() and not entry.name.startswith("_") and not entry.name.startswith("."):
                 names.append(entry.name)
+
+    # Return names in alphabetical order for nicer suggestions
+    names.sort(key=lambda n: n.lower())
     return names
 
 @app.route("/players")

--- a/static/playerSuggest.js
+++ b/static/playerSuggest.js
@@ -1,0 +1,35 @@
+// Enable scrollable suggestions for player input fields
+function enablePlayerSuggestions(input, players) {
+  if (!input) return;
+  const wrapper = input.parentElement;
+  if (!wrapper) return;
+  wrapper.style.position = wrapper.style.position || 'relative';
+
+  const box = document.createElement('div');
+  box.className = 'player-suggestions';
+  box.style.display = 'none';
+  wrapper.appendChild(box);
+
+  function renderList(value) {
+    const query = value.toLowerCase();
+    box.innerHTML = '';
+    players
+      .filter((p) => p.toLowerCase().includes(query))
+      .slice(0, 50)
+      .forEach((p) => {
+        const item = document.createElement('div');
+        item.textContent = p;
+        item.addEventListener('mousedown', (e) => {
+          e.preventDefault();
+          input.value = p;
+          box.style.display = 'none';
+        });
+        box.appendChild(item);
+      });
+    box.style.display = box.childElementCount ? 'block' : 'none';
+  }
+
+  input.addEventListener('input', () => renderList(input.value));
+  input.addEventListener('focus', () => renderList(input.value));
+  input.addEventListener('blur', () => setTimeout(() => (box.style.display = 'none'), 100));
+}

--- a/static/style.css
+++ b/static/style.css
@@ -59,6 +59,36 @@ form {
   flex-basis: 180px;
 }
 
+/* Scrollable suggestion list for player datalists */
+datalist#player-list {
+  max-height: 150px;
+  overflow-y: auto;
+}
+
+/* Custom scrollable suggestions dropdown */
+.player-suggestions {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  margin-top: 2px;
+  background: #2c2c2e;
+  border: 1px solid #333;
+  border-radius: 6px;
+  max-height: 150px;
+  overflow-y: auto;
+  z-index: 1000;
+}
+
+.player-suggestions div {
+  padding: 0.25rem 0.4rem;
+  cursor: pointer;
+}
+
+.player-suggestions div:hover {
+  background: #444;
+}
+
 /* Ensure dropdowns expand to fill the available row width */
 .form-row select {
   max-width: none;

--- a/templates/search.html
+++ b/templates/search.html
@@ -5,6 +5,7 @@
     <title>Search Clips</title>
     <link rel="stylesheet" href="/static/style.css" />
     <script>
+      const playerNames = {{ players|tojson }};
       function toggleSide(event) {
         document
           .querySelectorAll(".toggle-button")
@@ -38,6 +39,12 @@
           tag.style.display = text.includes(query) ? "block" : "none";
         });
       }
+      window.addEventListener("DOMContentLoaded", () => {
+        enablePlayerSuggestions(
+          document.querySelector('input[name="player"]'),
+          playerNames
+        );
+      });
     </script>
   </head>
   <body>
@@ -194,5 +201,6 @@
     </div>
   </body>
   <script src="{{ url_for('static', filename='taggerData.js') }}"></script>
+  <script src="{{ url_for('static', filename='playerSuggest.js') }}"></script>
   <script src="/static/search.js"></script>
 </html>

--- a/templates/tagger.html
+++ b/templates/tagger.html
@@ -59,6 +59,10 @@
             opt.value = p;
             list.appendChild(opt);
           });
+          enablePlayerSuggestions(
+            document.querySelector('input[name="player"]'),
+            data.players
+          );
         } catch (e) {
           console.error("Failed to load players", e);
         }
@@ -299,5 +303,6 @@
 
     <!-- Inject tag data -->
     <script src="{{ url_for('static', filename='taggerData.js') }}"></script>
+    <script src="{{ url_for('static', filename='playerSuggest.js') }}"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- sort player folder names before returning suggestions
- add scrollable dropdown for player names in tagger and search pages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f80d0a0148326b38251839f6ca46a